### PR TITLE
feat(asset_taxonomy.ttl): add DemandAndCapacityNotification API

### DIFF
--- a/taxonomy/asset_taxonomy.ttl
+++ b/taxonomy/asset_taxonomy.ttl
@@ -142,3 +142,8 @@ cx-taxo:Asset a skos:Concept ;
         skos:broader cx-taxo:Asset;
         skos:prefLabel "Receive ID Based Comment for DCM"@en;
         skos:definition "API to receive an ID Based Comment in DCM context".
+
+    cx-taxo:DemandAndCapacityNotificationApi a skos:Concept;
+        skos:broader cx-taxo:Asset;
+        skos:prefLabel "Receive Demand And Capacity Notification"@en;
+        skos:definition "API to receive an Demand And Capacity Notifications to inform about disruptions in supply chains".


### PR DESCRIPTION
<!--
 * Copyright (c) 2022,2023 Contributors to the Catena-X Association
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Apache License, Version 2.0 which is available at
 * https://www.apache.org/licenses/LICENSE-2.0.
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 * SPDX-License-Identifier: Apache-2.0
-->

## WHAT

Add DemandAndCapacityNotification to CX-Taxo as it has been missing in for CX-0146

## WHY

Missing since 24.05 release. See e.g. [usage in latest update to be merged.](https://github.com/catenax-eV/product-standardization-prod/pull/360/files#diff-a1bfb248af584efff1368d900a66fa125f8076dd8e93f6db72be3bcef467561fR529)

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes https://github.com/catenax-eV/cx-ex-PURIS/issues/76
